### PR TITLE
configurar middleware CORS #2

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const cors = require('cors');
+const Pert = require('./services/pert');
+const bodyParser = require('body-parser');
+const app = express();
+
+app.use(cors({ origin: 'http://localhost:4200' }));
+
+app.use(bodyParser.json());
+
+app.listen(3000, () => {
+    console.log('Servidor escuchando en el puerto 3000');
+});


### PR DESCRIPTION
Close #2 

- [x] Instalar el paquete cors.
- [x] Configurar CORS en server.js para permitir solicitudes desde http://localhost:4200/.
- [x] Probar que las solicitudes desde el frontend son aceptadas sin errores de CORS.